### PR TITLE
Add vitest tests for parseType

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "esbuild:install": " node ./node_modules/esbuild/install.js",
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "dexie": "^3.0.3",
@@ -35,6 +36,7 @@
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
     "tailwindcss": "^2.1.2",
-    "vite": "^2.4.3"
+    "vite": "^2.4.3",
+    "vitest": "^0.34.0"
   }
 }

--- a/src/store/globalstate.js
+++ b/src/store/globalstate.js
@@ -6,7 +6,7 @@ import { defaultSettings } from '@/plugins/defaultSettings.js'
 
 const storeItemSubscribers = {}
 
-const parseType = (value, type) => {
+export const parseType = (value, type) => {
   if (type === 'number') {
     return +value
   }

--- a/tests/globalstate.test.js
+++ b/tests/globalstate.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { parseType } from '../src/store/globalstate.js'
+
+describe('parseType', () => {
+  it('parses numbers', () => {
+    expect(parseType('1', 'number')).toBe(1)
+  })
+
+  it('parses booleans', () => {
+    expect(parseType('true', 'boolean')).toBe(true)
+  })
+
+  it('leaves strings unchanged', () => {
+    expect(parseType('hello', 'string')).toBe('hello')
+  })
+})


### PR DESCRIPTION
## Summary
- export `parseType` helper
- test `parseType` with vitest
- add vitest and npm test script

## Testing
- `npm test` *(fails: `vitest` not found)*