### PR TITLE
Use vue-test-utils for component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "stylelint-config-standard": "^38.0.0",
     "typescript": "^5.4.5",
     "vite": "^6.3.5",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "@vue/test-utils": "^2.4.6"
   }
 }

--- a/tests/components/Button.test.ts
+++ b/tests/components/Button.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Button from '../../src/components/Button.vue'
+
+describe('Button.vue', () => {
+  it('renders provided text', () => {
+    const wrapper = mount(Button, {
+      props: { text: 'Click me', loading: false },
+    })
+    expect(wrapper.text()).toContain('Click me')
+  })
+})

--- a/tests/components/InputBoolean.test.ts
+++ b/tests/components/InputBoolean.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import InputBoolean from '../../src/components/InputBoolean.vue'
+
+describe('InputBoolean.vue', () => {
+  it('toggles value on click', async () => {
+    const wrapper = mount(InputBoolean, {
+      props: { modelValue: false },
+    })
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([true])
+  })
+})

--- a/tests/components/InputTextField.test.ts
+++ b/tests/components/InputTextField.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import InputTextField from '../../src/components/InputTextField.vue'
+
+describe('InputTextField.vue', () => {
+  it('updates bound model value', async () => {
+    const wrapper = mount(InputTextField, {
+      props: { modelValue: '' },
+    })
+    const input = wrapper.find('input')
+    await input.setValue('hello')
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['hello'])
+  })
+})

--- a/tests/components/LoadingIcon.test.ts
+++ b/tests/components/LoadingIcon.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LoadingIcon from '../../src/components/LoadingIcon.vue'
+
+describe('LoadingIcon.vue', () => {
+  it('renders spinner icon', () => {
+    const wrapper = mount(LoadingIcon)
+    const icon = wrapper.find('i')
+    expect(icon.classes()).toContain('fa-spinner')
+  })
+})

--- a/tests/components/NumberDue.test.ts
+++ b/tests/components/NumberDue.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import NumberDue from '../../src/components/NumberDue.vue'
+
+describe('NumberDue.vue', () => {
+  it('applies color classes when value > 0', () => {
+    const wrapper = mount(NumberDue, { props: { value: 3, color: 'red' } })
+    expect(wrapper.classes()).toContain('text-red-500')
+  })
+})

--- a/tests/components/ProgressBar.test.ts
+++ b/tests/components/ProgressBar.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ProgressBar from '../../src/components/ProgressBar.vue'
+
+describe('ProgressBar.vue', () => {
+  it('calculates progress correctly', () => {
+    const wrapper = mount(ProgressBar, {
+      props: { value: 5, total: 10 },
+    })
+    expect(wrapper.text()).toContain('50')
+  })
+})

--- a/tests/scheduler.test.skip.ts
+++ b/tests/scheduler.test.skip.ts
@@ -7,6 +7,7 @@ import {
   _lapseIvl,
   _graduatingIvl,
   _rescheduleAsRev,
+  _rescheduleRev,
   _checkLeech,
   _nextRevIvl,
   _earlyReviewIvl,
@@ -40,6 +41,20 @@ import {
 import * as collection from '../src/plugins/collection.js'
 import * as globalstate from '../src/store/globalstate.js'
 import { wankidb } from '../src/plugins/wankidb/db.js'
+
+// Attach scheduler helpers to the global object so they can be spied on in tests
+Object.assign(globalThis, {
+  _daysLate,
+  _startingLeft,
+  _rescheduleLrnCard,
+  _rescheduleLapse,
+  _rescheduleAsRev,
+  _rescheduleRev,
+  _moveToNextStep,
+  _updateRevIvlOnFail,
+  mToday: 0,
+  mDayCutoff: 0,
+})
 
 // Mock dependencies
 vi.mock('../src/plugins/wankidb/db.js', () => {


### PR DESCRIPTION
## Summary
- switch existing component tests to use `@vue/test-utils`
- add new tests for LoadingIcon and NumberDue components
- declare `@vue/test-utils` in dev dependencies

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: cannot resolve @vue/test-utils)*