### PR TITLE
Add debug dot indicator

### DIFF
--- a/src/components/ButtonIcon.vue
+++ b/src/components/ButtonIcon.vue
@@ -4,6 +4,10 @@
     class="relative h-12 w-12 cursor-pointer rounded-full dark:text-white"
   >
     <i :class="icon"></i>
+    <div
+      v-if="showDot"
+      class="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-600"
+    ></div>
     <slot name="content" />
   </button>
 </template>
@@ -11,9 +15,11 @@
 <script setup lang="ts">
 interface Props {
   icon?: string
+  showDot?: boolean
 }
 
 withDefaults(defineProps<Props>(), {
   icon: 'far fa-sun',
+  showDot: false,
 })
 </script>

--- a/src/pages/Overview.vue
+++ b/src/pages/Overview.vue
@@ -4,7 +4,11 @@
       <FlexSpacer />
       <ButtonIconReload />
       <ThemeSwitcher />
-      <ButtonIcon icon="fas fa-spider" @click="toggleDebugging" />
+      <ButtonIcon
+        icon="fas fa-spider"
+        :show-dot="showDebugDot"
+        @click="toggleDebugging"
+      />
       <ButtonOptions
         :value="[
           { value: 'import', text: 'Import' },
@@ -131,6 +135,7 @@ import { Deck } from 'plugins/wankidb/types.ts'
 import DebuggingTimeControls from '@/components/DebuggingTimeControls.vue'
 import { refstorage } from '@/store/globalstate'
 import ButtonIcon from 'components/ButtonIcon.vue'
+import { getTimeOffset } from '@/plugins/time'
 
 // Build date from Vite environment variable
 const buildDate = __BUILD_DATE__
@@ -151,6 +156,7 @@ const loadingOnExport = ref(false)
 // Initialize debugging state in refstorage if not already initialized
 refstorage.init('testing.debugging', false)
 const showDebugging = computed(() => refstorage.get('testing.debugging', false))
+const showDebugDot = computed(() => getTimeOffset() !== 0)
 const inputRename = ref<string>('')
 const modalOptionsItem = ref<{ deck: Deck } | null>(null)
 const optionsFloating = ref([

--- a/src/pages/Review.vue
+++ b/src/pages/Review.vue
@@ -3,7 +3,11 @@
     <TheHeader>
       <FlexSpacer />
       <ThemeSwitcher />
-      <ButtonIcon icon="fas fa-spider" @click="toggleDebugging" />
+      <ButtonIcon
+        icon="fas fa-spider"
+        :show-dot="showDebugDot"
+        @click="toggleDebugging"
+      />
       <ButtonIcon icon="fas fa-info-circle" @click="onInfo" />
       <ButtonOptions
         :value="[
@@ -73,6 +77,7 @@ import ReviewContainer from '@/components/ReviewContainer.vue'
 import DebuggingTimeControls from '@/components/DebuggingTimeControls.vue'
 import { Deck } from 'plugins/wankidb/Deck.ts'
 import { refstorage } from '@/store/globalstate'
+import { getTimeOffset } from '@/plugins/time'
 
 const router = useRouter()
 const route = useRoute()
@@ -81,6 +86,7 @@ const route = useRoute()
 refstorage.init('testing.debugging', false)
 // Use computed to reactively get the debugging state from refstorage
 const debug = computed(() => refstorage.get('testing.debugging', false))
+const showDebugDot = computed(() => getTimeOffset() !== 0)
 const deckid = ref(1)
 const deck = ref<Deck | undefined>(undefined)
 const card = ref(undefined)

--- a/tests/components/ButtonIcon.test.ts
+++ b/tests/components/ButtonIcon.test.ts
@@ -22,4 +22,14 @@ describe('ButtonIcon.vue', () => {
     })
     expect(wrapper.find('.content').exists()).toBe(true)
   })
+
+  it('shows dot when show-dot is true', () => {
+    const wrapper = mount(ButtonIcon, {
+      props: { showDot: true },
+      global: {
+        ...commonGlobal,
+      },
+    })
+    expect(wrapper.find('.bg-red-600').exists()).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- add show-dot prop to ButtonIcon
- indicate time manipulation in Overview and Review spiders
- test ButtonIcon show-dot

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_683c6d3200948329bd885eee9b581479