### PR TITLE
Implement back button modal closing

### DIFF
--- a/src/components/CardPreviewModal.vue
+++ b/src/components/CardPreviewModal.vue
@@ -4,6 +4,7 @@
     title="Preview"
     fullscreen
     no-gutters
+    close-on-back
     @close="onClose"
   >
     <div class="flex min-h-full flex-col">

--- a/tests/components/BaseModal.test.ts
+++ b/tests/components/BaseModal.test.ts
@@ -10,7 +10,9 @@ vi.mock('../../src/store/globalstate.ts', () => ({
 
 describe('BaseModal.vue', () => {
   it('emits open and close events', async () => {
-    const wrapper = mount(BaseModal, { props: { modelValue: false } })
+    const wrapper = mount(BaseModal, {
+      props: { modelValue: false, closeOnBack: true },
+    })
     ;(wrapper.vm as any).open()
     expect(wrapper.emitted('open')).toBeTruthy()
     ;(wrapper.vm as any).onClose()


### PR DESCRIPTION
## Summary
- support closing modals via browser back
- use new `close-on-back` prop for `CardPreviewModal`
- adjust BaseModal test

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_684732bcdf208329bf72089e4a645d69