### PR TITLE
Fix CSS not persisting when editing cards

### DIFF
--- a/src/pages/EditCard.vue
+++ b/src/pages/EditCard.vue
@@ -126,6 +126,7 @@ const onSave = async () => {
 
   // Update CSS in model
   model.value.css = css.value
+  await model.value.save()
 
   // Use the new setTemplate method to update the template in the card
   await card.value.setTemplate(template.value)


### PR DESCRIPTION
## Summary
- persist CSS updates on the card edit page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684739394d6c8329b427445807ded3d6